### PR TITLE
Publish webcomics via event bus

### DIFF
--- a/xkcd-data-hub-lite-core/src/main/kotlin/com/yonatankarp/xkcddatahublite/adapters/AdaptersConfig.kt
+++ b/xkcd-data-hub-lite-core/src/main/kotlin/com/yonatankarp/xkcddatahublite/adapters/AdaptersConfig.kt
@@ -1,11 +1,21 @@
 package com.yonatankarp.xkcddatahublite.adapters
 
 import com.fasterxml.jackson.databind.SerializationFeature
+import com.yonatankarp.xkcddatahublite.application.usecases.GetAllXkcdComics
+import com.yonatankarp.xkcddatahublite.application.usecases.StoreXkcdComics
+import com.yonatankarp.xkcddatahublite.domain.entity.WebComics
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.serialization.jackson.jackson
-import jdk.jfr.internal.jfc.model.SettingsLog.enable
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+import org.slf4j.LoggerFactory.getLogger
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.ApplicationRunner
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.scheduling.annotation.EnableScheduling
@@ -21,5 +31,34 @@ class AdaptersConfig {
                     enable(SerializationFeature.INDENT_OUTPUT)
                 }
             }
+            install(HttpTimeout) {
+                requestTimeoutMillis = 30_000 // the entire request
+                connectTimeoutMillis = 10_000 // connection to be established
+            }
         }
+
+    @Bean
+    fun dataChannel(
+        @Value("\${xkcd.fetch.max-queue-size}") maxQueueSize: Int,
+    ) = Channel<WebComics>(capacity = maxQueueSize)
+
+    @Bean
+    fun applicationRunner(
+        getAllXkcdComics: GetAllXkcdComics,
+        storeXkcdComics: StoreXkcdComics,
+        @Value("\${xkcd.fetch.on-startup}") fetchOnStartup: Boolean,
+    ) = ApplicationRunner {
+        CoroutineScope(Dispatchers.Default).launch {
+            when (fetchOnStartup) {
+                true -> launch { getAllXkcdComics() }
+                false -> logger.info("Skipping fetching on startup")
+            }
+
+            storeXkcdComics.registerConsumers()
+        }
+    }
+
+    companion object {
+        private val logger = getLogger(AdaptersConfig::class.java)
+    }
 }

--- a/xkcd-data-hub-lite-core/src/main/kotlin/com/yonatankarp/xkcddatahublite/application/usecases/GetAllXkcdComics.kt
+++ b/xkcd-data-hub-lite-core/src/main/kotlin/com/yonatankarp/xkcddatahublite/application/usecases/GetAllXkcdComics.kt
@@ -1,25 +1,38 @@
 package com.yonatankarp.xkcddatahublite.application.usecases
 
 import com.yonatankarp.xkcddatahublite.application.ports.XkcdClientPort
+import com.yonatankarp.xkcddatahublite.domain.entity.WebComics
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 
 @Component
-class GetAllXkcdComics(private val client: XkcdClientPort) {
+class GetAllXkcdComics(
+    private val client: XkcdClientPort,
+    private val channel: SendChannel<WebComics>,
+    @Value("\${xkcd.fetch.producers}") private val numberOfProducers: Int,
+) {
     suspend operator fun invoke() =
         coroutineScope {
-            val latestComicId = client.getLatestComicId()
-            for (id in 1..latestComicId) {
-                withContext(Dispatchers.IO) {
-                    runCatching {
-                        logger.info("Fetching comic $id")
-                        val comics = client.getComicsById(id)
-                        println(comics) // TODO: send over channel
-                    }.onFailure { logger.error("Failed to fetch comic $it") }
-                }
+            withContext(Dispatchers.IO) {
+                val latestComicId = client.getLatestComicId()
+                (1..latestComicId).chunked(latestComicId / numberOfProducers)
+                    .forEach { chunk ->
+                        launch(Dispatchers.IO) {
+                            chunk.forEach { id ->
+                                runCatching {
+                                    logger.info("Fetching comic $id")
+                                    val comics = client.getComicsById(id)
+                                    channel.send(comics)
+                                }.onFailure { logger.error("Failed to fetch comic $it") }
+                            }
+                        }
+                    }
             }
         }
 

--- a/xkcd-data-hub-lite-core/src/main/kotlin/com/yonatankarp/xkcddatahublite/application/usecases/StoreXkcdComics.kt
+++ b/xkcd-data-hub-lite-core/src/main/kotlin/com/yonatankarp/xkcddatahublite/application/usecases/StoreXkcdComics.kt
@@ -1,0 +1,30 @@
+package com.yonatankarp.xkcddatahublite.application.usecases
+
+import com.yonatankarp.xkcddatahublite.domain.entity.WebComics
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.launch
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+
+@Component
+class StoreXkcdComics(
+    private val channel: ReceiveChannel<WebComics>,
+    @Value("\${xkcd.fetch.consumers}") private val numberOfConsumers: Int,
+    private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO),
+) {
+    suspend fun registerConsumers() =
+        repeat(numberOfConsumers) { index ->
+            scope.launch {
+                for (data in channel) {
+                    logger.info("Coroutine $index received: ${data.id} - ${data.title}")
+                }
+            }
+        }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(StoreXkcdComics::class.java)
+    }
+}

--- a/xkcd-data-hub-lite-core/src/main/resources/application.yml
+++ b/xkcd-data-hub-lite-core/src/main/resources/application.yml
@@ -17,10 +17,17 @@ management:
     health:
       probes.enabled: true
       show-details: always
-      livenessState.enabled: true
-      readinessState.enabled: true
+  health:
+    livenessstate.enabled: true
+    readinessstate.enabled: true
 
 xkcd:
   base-url: https://xkcd.com
   cronjob:
-    schedule: "0 * * * * *"
+    schedule: "0 0 */12 * * *"
+  fetch:
+    on-startup: true
+    producers: 10
+    consumers: 15
+    max-queue-size: 50
+


### PR DESCRIPTION


# Purpose

This commit allows the service to run multiple producers calling the XKCD API and publishing webcomics to multiple producers via an internal event bus.

This will be a preparation step before the consumers can take the webcomics and persist them into openserach.

# Types of changes

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring

# Checklist

- [ ] Documentation is updated
- [ ] No new tests are needed

