### PR TITLE
Fix Dependabot auto-merge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       dockerfile-path: Dockerfile
 
   dependabot_auto_merge:
-    needs: pipeline
+    needs: [ pipeline, linters ]
     if: ${{ github.actor == 'dependabot[bot]' }}
     permissions:
       contents: write


### PR DESCRIPTION
Fix Dependabot auto-merge wiring based on fresh GitHub API/check-log evidence. Keeps the shared reusable workflow in use; repo-local changes only correct dependency ordering or missing wiring.